### PR TITLE
Main 페이지 마크업 정리

### DIFF
--- a/src/components/LeftBar.js
+++ b/src/components/LeftBar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, Typography } from '@mui/material';
+import { Grid } from '@mui/material';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -18,29 +18,44 @@ export default function LeftBar() {
         <Grid item md={12}>
           <SimpleProfile />
         </Grid>
-        <Grid item md={12}>
-            <Button>Home</Button>
-          <Link to="/main">
-            <Typography>home</Typography>
-          </Link>
-        </Grid>
-        <Grid item md={12}>
-          <Typography>create</Typography>
-        </Grid>
-        <Grid item md={12}>
-          <Link to="/main/trends">
-            <Typography>trends</Typography>
-          </Link>
-        </Grid>
-        <Grid item md={12}>
-          <Link to="/main/wallet">
-            <Typography>wallet</Typography>
-          </Link>
-        </Grid>
-        <Grid item md={12}>
-          <Link to="/main/notification">
-            <Typography>notification</Typography>
-          </Link>
+        <Grid item md={1} />
+        <Grid item md={11}>
+          <Grid container rowSpacing={3}>
+            <Grid item md={12}>
+              <Button variant="text">
+                <Link to="/main" style={{ textDecoration: 'none' }}>
+                  Home
+                </Link>
+              </Button>
+            </Grid>
+            <Grid item md={12}>
+              <Button variant="text">Create</Button>
+            </Grid>
+            <Grid item md={12}>
+              <Button variant="text">
+                <Link to="/main/trends" style={{ textDecoration: 'none' }}>
+                  Trends
+                </Link>
+              </Button>
+            </Grid>
+            <Grid item md={12}>
+              <Button variant="text">
+                <Link to="/main/wallet" style={{ textDecoration: 'none' }}>
+                  Wallet
+                </Link>
+              </Button>
+            </Grid>
+            <Grid item md={12}>
+              <Button variant="text">
+                <Link
+                  to="/main/notification"
+                  style={{ textDecoration: 'none' }}
+                >
+                  Notification
+                </Link>
+              </Button>
+            </Grid>
+          </Grid>
         </Grid>
       </Grid>
     </Grid>

--- a/src/components/RightBar.js
+++ b/src/components/RightBar.js
@@ -1,16 +1,51 @@
-import { Grid, Typography } from '@mui/material';
+import {
+  Avatar,
+  Grid,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Typography,
+} from '@mui/material';
 import React from 'react';
+import { tokenNames, tokenPrices, avatars } from '../dummyData';
 
 export default function RightBar() {
+  const tokens = tokenNames.map((name, index) => ({
+    name,
+    price: tokenPrices[index],
+    avatar: avatars[index],
+  }));
   return (
     <Grid item md={3}>
       <Grid container>
-        <Grid item md={12}>
-          <Typography>trend</Typography>
+        <Grid item md={1} />
+        <Grid item md={11}>
+          <Typography>Top {tokenNames.length}</Typography>
         </Grid>
         <Grid item md={12}>
+          {tokens.map(({ name, price, avatar }, index) => (
+            <ListItem key={index}>
+              <ListItemAvatar>
+                <Avatar src={avatar} />
+              </ListItemAvatar>
+              <ListItemText
+                primary={
+                  <Grid container>
+                    <Grid item md={8}>
+                      <Typography>{name}</Typography>
+                    </Grid>
+                    <Grid item md={4}>
+                      <Typography>~${price}</Typography>
+                    </Grid>
+                  </Grid>
+                }
+              />
+            </ListItem>
+          ))}
+        </Grid>
+        {/* <Grid item md={12}>
           <Typography>Pravacy & rules</Typography>
-        </Grid>
+        </Grid> */}
       </Grid>
     </Grid>
   );

--- a/src/components/SimpleProfile.js
+++ b/src/components/SimpleProfile.js
@@ -1,30 +1,39 @@
 import React from 'react';
-import { Grid, Typography } from '@mui/material';
-import FaceIcon from '@mui/icons-material/Face';
+import { Avatar, Grid, Typography, Divider } from '@mui/material';
 import { Link } from 'react-router-dom';
+import avatar from '../assets/images/cosmonaut1.jpeg';
 
 export default function SimpleProfile() {
   return (
     <>
-      <Grid container>
-        <Grid item md={3}>
+      <Grid container rowSpacing={2}>
+        <Grid item md={1} />
+        <Grid item md={2}>
           <Link to="/main/profile">
-            <FaceIcon />
+            <Avatar alt="cosmonaut1" src={avatar} />
           </Link>
         </Grid>
         <Grid item md={9}>
           <Grid container>
             <Grid item md={12}>
-              <Typography>name</Typography>
+              <Typography>cosmonaut</Typography>
             </Grid>
             <Grid item md={12}>
-              <Typography>token price</Typography>
+              <Typography>$3,599</Typography>
             </Grid>
           </Grid>
         </Grid>
-        <Grid item md={12}>
-          <Typography>simple description</Typography>
+        <Grid item md={1} />
+        <Grid item md={11}>
+          <Typography>Hello~ I`m cosmonaut. </Typography>
+          <Typography>Nice to meet you!</Typography>
         </Grid>
+        <Grid item md={12} />
+        <Grid item md={12}>
+          <Divider variant="middle" />
+        </Grid>
+        <Grid item md={12} />
+        <Grid item md={12} />
       </Grid>
     </>
   );

--- a/src/dummyData.js
+++ b/src/dummyData.js
@@ -1,0 +1,22 @@
+import img1 from './assets/images/cosmonaut1.jpeg';
+import img2 from './assets/images/cosmonaut2.jpeg';
+import img3 from './assets/images/cosmonaut3.jpeg';
+import img4 from './assets/images/cosmonaut4.jpeg';
+import img5 from './assets/images/cosmonaut5.png';
+
+export const tokenNames = [
+  'pulse',
+  'cloutpunk',
+  'spookies',
+  'cloutfeed',
+  'Moonbounce',
+];
+export const tokenPrices = [
+  '5,204.68',
+  '4,253.34',
+  '2,597.59',
+  '1,988.71',
+  '1,912.89',
+];
+
+export const avatars = [img1, img2, img3, img4, img5];

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,4 +1,4 @@
-import { Grid, Typography } from '@mui/material';
+import { Grid, Box, Tabs, Tab } from '@mui/material';
 import React from 'react';
 import View from '../components/Post/View';
 
@@ -6,27 +6,31 @@ import img from '../assets/images/imgTest.jpeg';
 import img2 from '../assets/images/cosmos.jpeg';
 
 export default function Main() {
+  const [value, setValue] = React.useState(0);
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
   return (
-    <>
-      <Grid container>
-        <Grid item md={4}>
-          <Typography>Global</Typography>
-        </Grid>
-        <Grid item md={4}>
-          <Typography>following</Typography>
-        </Grid>
-        <Grid item md={4}>
-          <Typography>NFTs</Typography>
-        </Grid>
+    <Grid container rowSpacing={2}>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs
+          value={value}
+          onChange={handleChange}
+          aria-label="basic tabs example"
+        >
+          <Tab label="Global" />
+          <Tab label="Following" />
+          <Tab label="NFTs" />
+        </Tabs>
+      </Box>
+
+      <Grid item md={12}>
+        <View img={img} />
       </Grid>
-      <Grid container>
-        <Grid item md={12}>
-          <View img={img} />
-        </Grid>
-        <Grid item md={12}>
-          <View img={img2} />
-        </Grid>
+      <Grid item md={12}>
+        <View img={img2} />
       </Grid>
-    </>
+    </Grid>
   );
 }

--- a/src/pages/Trends.js
+++ b/src/pages/Trends.js
@@ -1,42 +1,47 @@
 import {
   Avatar,
   Grid,
-  List,
   ListItem,
   ListItemAvatar,
   ListItemText,
   Typography,
 } from '@mui/material';
 import React from 'react';
-import FaceIcon from '@mui/icons-material/Face';
-import { generate } from '../helpers';
+import { tokenNames, tokenPrices, avatars } from '../dummyData';
 
 export default function Trends() {
+  const tokens = tokenNames.map((name, index) => ({
+    name,
+    price: tokenPrices[index],
+    avatar: avatars[index],
+  }));
+
   return (
-    <>
-      <List>
-        {generate(
-          <ListItem>
+    <Grid container>
+      {/* <Grid item md={12}>
+        <Typography variant="h5">Trends</Typography>
+      </Grid> */}
+      <Grid item md={12}>
+        {tokens.map(({ name, price, avatar }, index) => (
+          <ListItem key={index}>
             <ListItemAvatar>
-              <Avatar>
-                <FaceIcon />
-              </Avatar>
+              <Avatar src={avatar} />
             </ListItemAvatar>
             <ListItemText
               primary={
                 <Grid container>
                   <Grid item md={8}>
-                    <Typography>이름</Typography>
+                    <Typography>{name}</Typography>
                   </Grid>
                   <Grid item md={4}>
-                    <Typography>코인 가격</Typography>
+                    <Typography>~${price}</Typography>
                   </Grid>
                 </Grid>
               }
             />
-          </ListItem>,
-        )}
-      </List>
-    </>
+          </ListItem>
+        ))}
+      </Grid>
+    </Grid>
   );
 }


### PR DESCRIPTION
### 작업
- `dummyData`에서 렌더링에 사용할 더미데이터 관리
- privacy & rules 부분에는 어떤거 들어가야할 지 몰라서 일단은 제거
- Grid 마크업 정리
<img width="1242" alt="스크린샷 2021-12-08 오전 2 34 21" src="https://user-images.githubusercontent.com/37647326/145078285-cd1693f5-30af-497c-8b9c-ddd5eda86f47.png">


### 이후 작업
- [x] profile, trends, wallet, notification 페이지 bitclout 클론 형태로 작업 예정

- [ ] profile(프로필 페이지 이 페이지 참고하는거 맞는지 확인 필요)
<img width="598" alt="스크린샷 2021-12-08 오전 2 40 06" src="https://user-images.githubusercontent.com/37647326/145079191-57333286-4cf3-4c82-a14c-f5cd8e9e3211.png">

- [x] trends
<img width="1233" alt="스크린샷 2021-12-08 오전 2 37 26" src="https://user-images.githubusercontent.com/37647326/145078774-afc1eba1-f14d-45f8-8b6e-7452e9c14308.png">

- [x] wallet
<img width="604" alt="스크린샷 2021-12-08 오전 2 38 49" src="https://user-images.githubusercontent.com/37647326/145078934-f3872a47-fd84-47dd-883f-9cd027688eed.png">

- [x] notifications
<img width="609" alt="스크린샷 2021-12-08 오전 2 39 13" src="https://user-images.githubusercontent.com/37647326/145078993-de5044f6-a093-4ded-8cd1-ff0a2acd2bd8.png">


